### PR TITLE
Add clean knowledge base api

### DIFF
--- a/app/server/api/knowledge_base_api.py
+++ b/app/server/api/knowledge_base_api.py
@@ -45,11 +45,14 @@ def update_knowledge_base_by_id(knowledge_base_id: str):
 
 
 @knowledgebases_bp.route("/<string:knowledge_base_id>", methods=["DELETE"])
-def delete_knowledge_base_by_id(knowledge_base_id: str):
+def clean_knowledge_base_by_id(knowledge_base_id: str):
     """Delete a knowledge base by ID."""
     manager = KnowledgeBaseManager()
+    data: Dict[str, Any] = cast(Dict[str, Any], request.json)
 
-    result, message = manager.delete_knowledge_base(id=knowledge_base_id)
+    drop: bool = data.get("drop", True)
+
+    result, message = manager.clean_knowledge_base(id=knowledge_base_id, drop=drop)
     return make_response(data=result, message=message)
 
 

--- a/app/server/manager/knowledge_base_manager.py
+++ b/app/server/manager/knowledge_base_manager.py
@@ -46,17 +46,18 @@ class KnowledgeBaseManager:
         )
         return {}, f"Knowledge base with ID {id} edited successfully"
 
-    def delete_knowledge_base(self, id: str) -> Tuple[Dict[str, Any], str]:
-        """Delete a knowledge base by ID.
+    def clean_knowledge_base(self, id: str, drop: bool) -> Tuple[Dict[str, Any], str]:
+        """Clean a knowledge base by ID.
 
         Args:
             id (str): ID of the knowledge base
+            drop (bool): D  rop the entire knowledge base after cleaning or not.
 
         Returns:
-            Tuple[Dict[str, Any], str]: A tuple containing deletion status and success message
+            Tuple[Dict[str, Any], str]: A tuple containing clean status and success message
         """
-        self._knowledge_base_service.delete_knowledge_base(id=id)
-        return {}, f"Knowledge base with ID {id} deleted successfully"
+        self._knowledge_base_service.clean_knowledge_base(id=id, drop=drop)
+        return {}, f"Knowledge base with ID {id} cleaned successfully"
 
     def get_all_knowledge_bases(self) -> Tuple[dict, str]:
         """


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/TuGraph-family/chat2graph/blob/master/community/CONTRIBUTING.md
-->

## Title
<!--
And make sure that the title of your pull request follows the following format:
`<type>(<scope>): <subject>`

`<type>` is the type of your pull request.
`<scope>` is optional (including `()`) when you choose `none`.
`<subject>` is a concise sentence in lowercase.
-->

**Type**
<!-- What is the type of your pull request? Open the item by `[x]` way. -->

- [ ] `feat`: (new feature)
- [ ] `fix`: (bug fix)
- [ ] `docs`: (doc update)
- [ ] `style`: (update format)
- [ ] `refactor`: (refactor code)
- [ ] `test`: (test code)
- [ ] `chore`: (other updates)

**Scope**
<!-- Which module does your pull request mainly modify? Select `none` when undetermined. -->

- [ ] `web`: (web front-end module)
- [ ] `server`: (web server module)
- [ ] `dal`: (data access layer)
- [ ] `sdk`: (sdk module)
- [ ] `planner`: (planner/leader module)
- [ ] `workflow`: (workflow module)
- [ ] `knowledge`: (knowledge module)
- [ ] `toolkit`: (toolkit module)
- [ ] `reasoner`: (reasoner module)
- [ ] `memory`: (memory module)
- [ ] `model`: (model/LLM module)
- [ ] `env`: (env module)
- [ ] `resource`: (resource module)
- [ ] `tracer`: (tracer module)
- [ ] `plugin`: (plugin module)
- [ ] `none`: (no module)

### Description
<!-- Provide the relevant issue number associated with your pull request if needed. -->

**Issue:** #

<!-- Provide more information about this pull request. -->

### Checklist

- [ ] I have prepared the pull request title according to the requirements.
- [ ] I have successfully run all unit tests and integration tests.
- [ ] I have followed the code style guidelines of this project.
- [ ] I have already rebased the latest `master` branch.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.

