### PR TITLE
feat(web): add default options for database type, host and port

### DIFF
--- a/web/src/pages/Graphdb/components/GraphDataModal/index.tsx
+++ b/web/src/pages/Graphdb/components/GraphDataModal/index.tsx
@@ -5,112 +5,118 @@ import neo4j from "@/assets/neo4j.png"
 import tugraph from "@/assets/tugraph.png"
 import { useEffect } from "react"
 
-
-
 const { Option } = Select
-
-
 interface IGraphDataModalProps {
-    open: boolean
-    onClose: () => void
-    editId: string | null
-    onFinish: () => void
-    formatMessage: (key: string) => string
+  open: boolean
+  onClose: () => void
+  editId: string | null
+  onFinish: () => void
+  formatMessage: (key: string) => string
 }
 const GraphDataModal: React.FC<IGraphDataModalProps> = ({
-    open,
-    onClose,
-    editId,
-    onFinish,
-    formatMessage,
+  open,
+  onClose,
+  editId,
+  onFinish,
+  formatMessage,
 }) => {
-    const [form] = Form.useForm()
-    const { getDatabaseDetail, databaseEntity, loadingGetGraphdbById, runCreateGraphdbs, loadingCreateGraphdbs, runUpdateGraphdbs, loadingUpdateGraphdbs } = useDatabaseEntity();
+  const [form] = Form.useForm()
+  const { getDatabaseDetail, databaseEntity, loadingGetGraphdbById, runCreateGraphdbs, loadingCreateGraphdbs, runUpdateGraphdbs, loadingUpdateGraphdbs } = useDatabaseEntity();
 
-
-
-    useEffect(() => {
-        if (editId) {
-            getDatabaseDetail(editId)
-        }
-    }, [editId])
-
-
-    useEffect(() => {
-        if (databaseEntity?.databaseDetail) {
-            form.setFieldsValue({
-                ...databaseEntity?.databaseDetail
-            })
-        }
-    }, [databaseEntity?.databaseDetail])
-    const onCancel = () => {
-        form.resetFields()
-        onClose()
+  useEffect(() => {
+    if (editId) {
+      getDatabaseDetail(editId)
     }
+  }, [editId])
 
-    const onSubmit = () => {
-        form.validateFields().then(async (values) => {
-            let res: any = {}
-            if (editId) {
-                res = await runUpdateGraphdbs({ session_id: editId }, {
-                    ...databaseEntity?.databaseDetail,
-                    ...values,
-                })
-            } else {
-                res = await runCreateGraphdbs({
-                    ...values,
-                })
-            }
+  useEffect(() => {
+    if (databaseEntity?.databaseDetail) {
+      form.setFieldsValue({
+        ...databaseEntity?.databaseDetail
+      })
+    }
+  }, [databaseEntity?.databaseDetail])
+  const onCancel = () => {
+    form.resetFields()
+    onClose()
+  }
 
-            if (res?.success) {
-                onFinish()
-                onCancel()
-                message.success(res?.message)
-            } else {
-                message.error(res?.message)
-            }
+  const onSubmit = () => {
+    form.validateFields().then(async (values) => {
+      let res: any = {}
+      if (editId) {
+        res = await runUpdateGraphdbs({ session_id: editId }, {
+          ...databaseEntity?.databaseDetail,
+          ...values,
         })
+      } else {
+        res = await runCreateGraphdbs({
+          ...values,
+        })
+      }
+
+      if (res?.success) {
+        onFinish()
+        onCancel()
+        message.success(res?.message)
+      } else {
+        message.error(res?.message)
+      }
+    })
+  }
+
+  const renderDom = (item: string, idx: number) => {
+    switch (item) {
+      case 'type':
+        return <Select placeholder={formatMessage(`database.modal.placeholder${idx}`)} style={{ height: 35 }}>
+          <Option value="NEO4J">
+            <img src={neo4j} style={{ height: 30 }} />
+          </Option>
+          <Option value="TUGRAPH">
+            <img src={tugraph} style={{ height: 25 }} /></Option>
+        </Select>;
+      case 'pwd':
+        return <Input.Password maxLength={50} placeholder={formatMessage(`database.modal.placeholder${idx}`)} />;
+      default:
+        return <Input maxLength={50} placeholder={formatMessage(`database.modal.placeholder${idx}`)} />;
     }
+  }
 
-
-    const renderDom = (item: string, idx: number) => {
-        switch (item) {
-            case 'type':
-                return <Select placeholder={formatMessage(`database.modal.placeholder${idx}`)} style={{ height: 35 }}>
-                    <Option value="NEO4J">
-                        <img src={neo4j} style={{ height: 30 }} />
-                    </Option>
-                    <Option value="TUGRAPH">
-                        <img src={tugraph} style={{ height: 25 }} /></Option>
-                </Select>;
-            case 'pwd': return <Input.Password maxLength={50} placeholder={formatMessage(`database.modal.placeholder${idx}`)} />;
-            default: return <Input maxLength={50} placeholder={formatMessage(`database.modal.placeholder${idx}`)} />;
-        }
-    }
-
-    const renderItem = (item: string, idx: number) => {
-        return <Form.Item label={formatMessage(`database.modal.label${idx}`)} name={item} rules={REQUIRED_MODAL_FORMS.includes(item) ? [{ required: true, message: formatMessage(`database.modal.placeholder${idx}`) }] : []}>
-            {renderDom(item, idx)}
-        </Form.Item>
-    }
-
-
-    return <Modal
-        title={<div style={{ fontSize: 20, fontWeight: 600, textAlign: 'center' }}>
-            {editId ? formatMessage('database.modal.title2') : formatMessage('database.modal.title1')}
-        </div>
-        }
-        open={open}
-        onCancel={onCancel}
-        onOk={onSubmit}
-        confirmLoading={loadingCreateGraphdbs || loadingUpdateGraphdbs || loadingGetGraphdbById}
+  const renderItem = (item: string, idx: number) => {
+    return <Form.Item
+      key={idx}
+      label={formatMessage(`database.modal.label${idx}`)}
+      name={item}
+      rules={REQUIRED_MODAL_FORMS.includes(item) ? [{ required: true, message: formatMessage(`database.modal.placeholder${idx}`) }] : []}
     >
-        <Form form={form} layout="vertical">
-            {
-                MODAL_FORMS?.map((key: string, idx: number) => renderItem(key, idx))
-            }
-        </Form>
-    </Modal>
+      {renderDom(item, idx)}
+    </Form.Item>
+  }
+
+  return <Modal
+    title={<div style={{ fontSize: 20, fontWeight: 600, textAlign: 'center' }}>
+      {editId ? formatMessage('database.modal.title2') : formatMessage('database.modal.title1')}
+    </div>
+    }
+    open={open}
+    onCancel={onCancel}
+    onOk={onSubmit}
+    confirmLoading={loadingCreateGraphdbs || loadingUpdateGraphdbs || loadingGetGraphdbById}
+  >
+    <Form
+      form={form}
+      layout="vertical"
+      initialValues={{
+        type: 'NEO4J',
+        host: 'localhost',
+        port: '7687',
+      }}
+    >
+      {
+        MODAL_FORMS?.map((key: string, idx: number) => renderItem(key, idx))
+      }
+    </Form>
+  </Modal>
 }
 
 export default GraphDataModal


### PR DESCRIPTION

<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/TuGraph-family/chat2graph/blob/master/community/CONTRIBUTING.md
-->

## Title
<!--
And make sure that the title of your pull request follows the following format:
`<type>(<scope>): <subject>`

`<type>` is the type of your pull request.
`<scope>` is optional (including `()`) when you choose `none`.
`<subject>` is a concise sentence in lowercase.
-->

**Type**
<!-- What is the type of your pull request? Open the item by `[x]` way. -->

- [x] `feat`: (new feature)
- [ ] `fix`: (bug fix)
- [ ] `docs`: (doc update)
- [ ] `style`: (update format)
- [ ] `refactor`: (refactor code)
- [ ] `test`: (test code)
- [ ] `chore`: (other updates)

**Scope**
<!-- Which module does your pull request mainly modify? Select `none` when undetermined. -->

- [x] `web`: (web front-end module)
- [ ] `server`: (web server module)
- [ ] `dal`: (data access layer)
- [ ] `sdk`: (sdk module)
- [ ] `planner`: (planner/leader module)
- [ ] `workflow`: (workflow module)
- [ ] `knowledge`: (knowledge module)
- [ ] `toolkit`: (toolkit module)
- [ ] `reasoner`: (reasoner module)
- [ ] `memory`: (memory module)
- [ ] `model`: (model/LLM module)
- [ ] `env`: (env module)
- [ ] `resource`: (resource module)
- [ ] `tracer`: (tracer module)
- [ ] `plugin`: (plugin module)
- [ ] `none`: (no module)

### Description
<!-- Provide the relevant issue number associated with your pull request if needed. -->

**Issue:** [#79](https://github.com/TuGraph-family/chat2graph/issues/79)

<!-- Provide more information about this pull request. -->

### Checklist

- [x] I have prepared the pull request title according to the requirements.
- [x] I have successfully run all unit tests and integration tests.
- [x] I have followed the code style guidelines of this project.
- [x] I have already rebased the latest `master` branch.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.

