### PR TITLE
fix(planner): enhance the parser of job dict

### DIFF
--- a/app/core/agent/leader.py
+++ b/app/core/agent/leader.py
@@ -640,6 +640,14 @@ class Leader(Agent):
             if missing_keys:
                 raise ValueError(f"Task '{task_id}' is missing required keys: {missing_keys}")
 
+            # convert list/dict to string for specific fields before type validation
+            for key_to_convert in ["goal", "context", "completion_criteria", "thinking"]:
+                if key_to_convert in task_data:
+                    if isinstance(task_data[key_to_convert], list):
+                        task_data[key_to_convert] = "\n".join(map(str, task_data[key_to_convert]))
+                    elif isinstance(task_data[key_to_convert], dict):
+                        task_data[key_to_convert] = json.dumps(task_data[key_to_convert])
+
             # validate types
             for key in ["goal", "context", "completion_criteria", "assigned_expert", "thinking"]:
                 if not isinstance(task_data[key], str):


### PR DESCRIPTION
…dation

<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/TuGraph-family/community/blob/master/docs/CONTRIBUTING.md
-->

## Title
<!--
And make sure that the title of your pull request follows the following format:
`<type>(<scope>): <subject>`

`<type>` is the type of your pull request.
`<scope>` is optional (including `()`) when you choose `none`.
`<subject>` is a concise sentence in lowercase.
-->

**Type**
<!-- What is the type of your pull request? Open the item by `[x]` way. -->

- [ ] `feat`: (new feature)
- [ ] `fix`: (bug fix)
- [ ] `docs`: (doc update)
- [ ] `style`: (update format)
- [ ] `refactor`: (refactor code)
- [ ] `test`: (test code)
- [ ] `chore`: (other updates)

**Scope**
<!-- Which module does your pull request mainly modify? Select `none` when undetermined. -->

- [ ] `app`: (**Application Layer**)
  - [ ] `web`: (web front-end module)
  - [ ] `server`: (web server module)
  - [ ] `dal`: (data access layer)
  - [ ] `sdk`: (sdk module)
- [ ] `agent`: (**Agent Layer**)
  - [ ] `reasoner`: (reasoner module)
  - [ ] `planner`: (planner module)
  - [ ] `workflow`: (workflow module)
  - [ ] `memory`: (memory module)
  - [ ] `knowledge`: (knowledge module)
  - [ ] `env`: (env module)
  - [ ] `toolkit`: (toolkit module)
- [ ] `system`: (**System Layer**)
  - [ ] `plugin`: (plugin module)
  - [ ] `tracer`: (tracer module)
  - [ ] `resource`: (resource module)
- [ ] `none`: (N/A)

### Description
<!-- Provide the relevant issue number associated with your pull request if needed. -->

**Issue:** #

<!-- Provide more information about this pull request. -->

### Checklist

- [ ] I have prepared the pull request title according to the requirements.
- [ ] I have successfully run all unit tests and integration tests.
- [ ] I have followed the code style guidelines of this project.
- [ ] I have already rebased the latest `master` branch.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.

