### PR TITLE
fix(env): update Gemini configuration for LiteLLM

### DIFF
--- a/app/core/common/system_env.py
+++ b/app/core/common/system_env.py
@@ -15,8 +15,8 @@ from app.core.common.type import (
 _env_vars: Dict[str, Tuple[Type, Any]] = {
     "WORKFLOW_PLATFORM_TYPE": (WorkflowPlatformType, WorkflowPlatformType.DBGPT),
     "MODEL_PLATFORM_TYPE": (ModelPlatformType, ModelPlatformType.LITELLM),
-    "LLM_NAME": (str, "openai/deepseek-ai/DeepSeek-V3"),
-    "LLM_ENDPOINT": (str, "https://api.siliconflow.cn/v1"),
+    "LLM_NAME": (str, None),
+    "LLM_ENDPOINT": (str, None),
     "LLM_APIKEY": (str, None),
     "TEMPERATURE": (float, 0.7),
     "MAX_TOKENS": (int, 1048576),

--- a/doc/en-us/deployment/config-env.md
+++ b/doc/en-us/deployment/config-env.md
@@ -53,8 +53,7 @@ LLM_APIKEY=
 
 ```env
 LLM_NAME=gemini/gemini-2.5-pro
-# LiteLLM handles the endpoint automatically, but set for consistency
-LLM_ENDPOINT=https://generativelanguage.googleapis.com/v1beta
+LLM_ENDPOINT=  # do not set the endpoint for Gemini, LiteLLM will use the default
 LLM_APIKEY=
 ```
 

--- a/doc/zh-cn/deployment/config-env.md
+++ b/doc/zh-cn/deployment/config-env.md
@@ -52,8 +52,8 @@ LLM_APIKEY=
 **场景 2: Google 官方 API**
 
 ```env
-LLM_NAME=gemini/gemini-1.5-pro
-LLM_ENDPOINT=https://generativelanguage.googleapis.com/v1beta
+LLM_NAME=gemini/gemini-2.5-pro
+LLM_ENDPOINT=  # do not set the endpoint for Gemini, LiteLLM will use the default
 LLM_APIKEY=
 ```
 


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/TuGraph-family/community/blob/master/docs/CONTRIBUTING.md
-->

## Title
<!--
And make sure that the title of your pull request follows the following format:
`<type>(<scope>): <subject>`

`<type>` is the type of your pull request.
`<scope>` is optional (including `()`) when you choose `none`.
`<subject>` is a concise sentence in lowercase.
-->

**Type**
<!-- What is the type of your pull request? Open the item by `[x]` way. -->

- [ ] `feat`: (new feature)
- [x] `fix`: (bug fix)
- [ ] `docs`: (doc update)
- [ ] `style`: (update format)
- [ ] `refactor`: (refactor code)
- [ ] `test`: (test code)
- [ ] `chore`: (other updates)

**Scope**
<!-- Which module does your pull request mainly modify? Select `none` when undetermined. -->

- [ ] `app`: (**Application Layer**)
  - [ ] `web`: (web front-end module)
  - [ ] `server`: (web server module)
  - [ ] `dal`: (data access layer)
  - [ ] `sdk`: (sdk module)
- [ ] `agent`: (**Agent Layer**)
  - [ ] `reasoner`: (reasoner module)
  - [ ] `planner`: (planner module)
  - [ ] `workflow`: (workflow module)
  - [ ] `memory`: (memory module)
  - [ ] `knowledge`: (knowledge module)
  - [ ] `env`: (env module)
  - [ ] `toolkit`: (toolkit module)
- [ ] `system`: (**System Layer**)
  - [ ] `plugin`: (plugin module)
  - [ ] `tracer`: (tracer module)
  - [ ] `resource`: (resource module)
- [ ] `none`: (N/A)

### Description
<!-- Provide the relevant issue number associated with your pull request if needed. -->

**Issue:** #

<!-- Provide more information about this pull request. -->

### Checklist

- [x] I have prepared the pull request title according to the requirements.
- [x] I have successfully run all unit tests and integration tests.
- [x] I have followed the code style guidelines of this project.
- [x] I have already rebased the latest `master` branch.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.

