### PR TITLE
fix(system): correct job_id assignment in WorkflowMessageDo

### DIFF
--- a/app/core/dal/dao/message_dao.py
+++ b/app/core/dal/dao/message_dao.py
@@ -76,7 +76,7 @@ class MessageDao(Dao[MessageDo]):
                 payload=WorkflowMessage.serialize_payload(message.get_payload()),
                 artifact_ids=message.get_artifact_ids(),
                 id=message.get_id(),
-                job_id=message.get_id(),
+                job_id=message.get_job_id(),
                 timestamp=message.get_timestamp(),
             )
 


### PR DESCRIPTION

---

## Type

- [x] `fix`: (bug fix)

---

## Scope

- [x] `agent`: (**Agent Layer**)  
  - [x] `workflow`: (workflow module)

---

## Description

**Issue:**  
In `app/core/dal/dao/message_dao.py`, the `WorkflowMessageDo` initialization incorrectly assigns the `job_id` field as `message.get_id()`.  
This causes the `job_id` in persisted records to point to the message ID instead of the actual job ID, leading to potential issues when querying messages by `job_id`.

**Fix:**  
Updated the assignment to use `message.get_job_id()` instead of `message.get_id()`.

### Before
```python
return WorkflowMessageDo(
    type=MessageType.WORKFLOW_MESSAGE.value,
    payload=WorkflowMessage.serialize_payload(message.get_payload()),
    artifact_ids=message.get_artifact_ids(),
    id=message.get_id(),
    job_id=message.get_id(),          # ❌ incorrect
    timestamp=message.get_timestamp(),
)
